### PR TITLE
fix: error: ‘uint64_t’ 'uint32_t' were not declared in this scope

### DIFF
--- a/src/BloomFilter.cpp
+++ b/src/BloomFilter.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "BloomFilter.h"
+#include <cstdint>
 
 BloomFilter::BloomFilter(long long sampleSize, int multiple):multiple(20) {
     if(sampleSize==0){

--- a/src/ReverseBloomFilter.h
+++ b/src/ReverseBloomFilter.h
@@ -8,6 +8,7 @@
 #include<iostream>
 #include<string.h>
 #include<math.h>
+#include <cstdint>
 using namespace::std;
 #define maxRBfSize 1024L*1024*1024*4
 #define minRBfSize 1024L*1024*500

--- a/src/rmdup.h
+++ b/src/rmdup.h
@@ -9,7 +9,8 @@
 #include<unordered_set>
 #include<vector>
 #include <cmath>
-#include <cstring>
+#include <string>
+#include <cstdint>
 #include "gc.h"
 using namespace::std;
 #define AUTHOREMAIL "gongchun@genomics.cn"


### PR DESCRIPTION
for gcc 13.1.1
```
g++ -std=c++11 -g -O3 -c src/BloomFilter.cpp -o obj/BloomFilter.o
src/BloomFilter.cpp: In member function ‘bool BloomFilter::getPosStatus(long int)’:
src/BloomFilter.cpp:146:5: error: ‘uint64_t’ was not declared in this scope
  146 |     uint64_t bigIdx=idx/8;
      |     ^~~~~~~~
```