### PR TITLE
fix: gcc13

### DIFF
--- a/src/BloomFilter.cpp
+++ b/src/BloomFilter.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "BloomFilter.h"
+#include <cstdint>
 
 BloomFilter::BloomFilter(long long sampleSize, int multiple):multiple(20) {
     if(sampleSize==0){

--- a/src/ReverseBloomFilter.h
+++ b/src/ReverseBloomFilter.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <string.h>
 #include <math.h>
+#include <cstdint>
 using namespace ::std;
 #define maxRBfSize 1024L * 1024 * 1024 * 4
 #define minRBfSize 1024L * 1024 * 1000

--- a/src/rmdup.h
+++ b/src/rmdup.h
@@ -10,6 +10,7 @@
 #include<vector>
 #include <cmath>
 #include <cstring>
+#include <cstdint>
 #include "gc.h"
 using namespace::std;
 #define AUTHOREMAIL "gongchun@genomics.cn"


### PR DESCRIPTION
gcc 13 fix patch
```
In file included from src/ReverseBloomFilter.cpp:5:
src/ReverseBloomFilter.h:17:9: error: ‘uint64_t’ does not name a type
   17 |         uint64_t curHash;
      |         ^~~~~~~~
src/ReverseBloomFilter.h:11:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?

```