### PR TITLE
fix: the code that 2.1.9 bring in can't be compied by gcc13

### DIFF
--- a/src/gc.cpp
+++ b/src/gc.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include "zlib.h"
 #include "gc.h"
+#include <cstdint>
 // #include<stdio.h>
 
 using namespace ::std;

--- a/src/gc.h
+++ b/src/gc.h
@@ -9,6 +9,7 @@
 #include <set>
 #include <map>
 #include <math.h>
+#include <cstdint>
 using namespace ::std;
 class quartile_result
 {

--- a/src/global_variable.cpp
+++ b/src/global_variable.cpp
@@ -1,4 +1,5 @@
 #include "global_variable.h"
+#include <cstdint>
 
 C_general_stat::C_general_stat()
 {

--- a/src/global_variable.h
+++ b/src/global_variable.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <set>
 #include "global_parameter.h"
+#include <cstdint>
 // #include <map>
 using namespace ::std;
 #define READ_MAX_LEN 1000


### PR DESCRIPTION
Hello, again, the newly added code can't be compied by GCC 13

you can check the log here https://build.bioarchlinux.org/api/pkg/soapnuke/log/1711627296