### PR TITLE
Add macOS compatibility for CPU core detection

### DIFF
--- a/src/process_argv.cpp
+++ b/src/process_argv.cpp
@@ -6,7 +6,11 @@
 #include <map>
 #include <fstream>
 #include "global_parameter.h"
+#ifdef __APPLE__
+#include <unistd.h>
+#else
 #include "sys/sysinfo.h"
+#endif
 // #include <string>
 using namespace ::std;
 #define ADA_RATIO 0.4
@@ -902,12 +906,17 @@ bool check_parameter(int argc, char *argv[], C_global_parameter &gp)
 	{
 		gp.clean_file_reads = gp.l_total_reads_num;
 	}
-	if (gp.threads_num > get_nprocs())
+	#ifdef __APPLE__
+		long nprocs = sysconf(_SC_NPROCESSORS_ONLN);
+	#else
+		int nprocs = get_nprocs();
+	#endif
+	if (gp.threads_num > nprocs)
 	{
-		gp.threads_num = get_nprocs();
+		gp.threads_num = nprocs;
 		cerr << "Warning:threads number exceeds the system cpu number" << endl;
 		// exit(1);
-	}
+	}	
 	if (gp.patchSize > 5000000)
 	{
 		cerr << "Error:patchSize cannot exceed 5M considering memory usage" << endl;


### PR DESCRIPTION
Hello BGI-flexlab team,

This Pull Request addresses a build error I encountered when compiling SOAPnuke on macOS systems.

**Problem**
When attempting to build SOAPnuke on macOS, the compilation process fails with the following error:
```
src/process_argv.cpp:9:10: fatal error: 'sys/sysinfo.h' file not found
```
This is because `sys/sysinfo.h` and the `get_nprocs()` function are part of the GNU C Library (glibc) and are not available on macOS (which uses a BSD-derived system). 

**Proposed Solution**
This PR introduces conditional compilation to use platform-specific headers and functions for retrieving the number of CPU processors. After implementing this PR, I was able to compile SOAPnuke on MacOS.

**Changes Made**

1.  **Conditional Header Include:** Replaced the direct inclusion of `"sys/sysinfo.h"` with a conditional block that includes `<unistd.h>` for macOS (`__APPLE__`) and retains `"sys/sysinfo.h"` for other systems.
2.  **Conditional CPU Count Retrieval:** Replaced the `get_nprocs()` function call with `sysconf(_SC_NPROCESSORS_ONLN)` within a conditional block for macOS. This ensures that the correct POSIX-compliant method is used on Apple platforms.

These changes ensure that SOAPnuke can be successfully compiled and run on macOS, significantly improving its portability and accessibility for users that use MacOS.

Thank you for considering this improvement.